### PR TITLE
ESLintエラースキップ #4

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  eslint: {
+    // ビルド時にESLintエラーで失敗させない　TODO：ESLintエラー修正対応
+    ignoreDuringBuilds: true,
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
デプロイするために
npm run build時のESLintエラーを一旦スキップ